### PR TITLE
désactive warning chargement reader

### DIFF
--- a/03_Fiches_thematiques/Fiche_import_fichiers_plats.Rmd
+++ b/03_Fiches_thematiques/Fiche_import_fichiers_plats.Rmd
@@ -20,7 +20,7 @@ Le *package* `readr` propose plusieurs fonctions adaptées pour importer des fic
 
 Il faut charger le *package* `readr` pour utiliser ces fonctions :
 
-```{r} 
+```{r, warning = FALSE} 
 library(readr)
 ```
 


### PR DESCRIPTION
Méchants warnings au chargement de readr : 
```r
library(readr)

## Warning: replacing previous import 'ellipsis::check_dots_unnamed' by
## 'rlang::check_dots_unnamed' when loading 'hms'

## Warning: replacing previous import 'ellipsis::check_dots_used' by
## 'rlang::check_dots_used' when loading 'hms'

## Warning: replacing previous import 'ellipsis::check_dots_empty' by
## 'rlang::check_dots_empty' when loading 'hms'
```

Ne sachant pas exactement la cause, je propose de les cacher.